### PR TITLE
wrongly-claimed-invalid-shape-identifiers

### DIFF
--- a/src/lib/blueprint.schema.ts
+++ b/src/lib/blueprint.schema.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
-import { decode, encode } from '$lib/blueprint';
+import { decode } from '$lib/blueprint';
 import {
 	BLUEPRINT_IDENTIFIER_REGEX,
 	BLUEPRINT_TYPES,
-	type Blueprint,
 	type BlueprintIdentifier
 } from '$lib/blueprint.types';
 
@@ -41,7 +40,7 @@ const BLUEPRINT_DATA_SCHEMA = z
 		try {
 			decode(value);
 			return true;
-		} catch (error) {
+		} catch {
 			return false;
 		}
 	}, 'Invalid blueprint data');

--- a/src/lib/components/shape/ShapeView.svelte
+++ b/src/lib/components/shape/ShapeView.svelte
@@ -10,6 +10,7 @@
 	import {
 		isDefaultShapeIdentifier,
 		SHAPE_COLOR_BASE_MATERIAL,
+		SHAPE_MAX_LAYERS,
 		type ShapeData
 	} from '$lib/shape.types';
 
@@ -17,7 +18,7 @@
 	import ShapeDefaultSupport from '$lib/components/models/shapes/ShapeDefaultSupport.svelte';
 
 	const SHAPE_LAYER_HEIGHT = 0.05;
-	const SHAPE_LAYER_SCALE = 0.2;
+	const SHAPE_LAYER_SCALE = 1 / SHAPE_MAX_LAYERS;
 	const SHAPE_LAYER_EXTEND_OFFSET = 0.15;
 	const SHAPE_PART_EXPAND_OFFSET = 0.4;
 
@@ -177,7 +178,6 @@
 						value={$page.data.shape?.identifier ?? null}
 						required
 						minlength="2"
-						maxlength="51"
 					/>
 
 					<button class="btn btn-square btn-ghost btn-sm" type="reset" title="Clear shape input">
@@ -215,7 +215,7 @@
 						<ShapeDefaultSupport position.y={-0.025} bind:this={baseComponentModel} />
 					</Suspense>
 					{#key data}
-						{#each data.data as layer, layerIndex}
+						{#each data.data.slice(0,SHAPE_MAX_LAYERS) as layer, layerIndex}
 							{@const layerPositionY = layerIndex * SHAPE_LAYER_HEIGHT}
 							{@const layerScale = 1 - layerIndex * SHAPE_LAYER_SCALE}
 							{@const extendOffset = isExtended ? layerIndex * SHAPE_LAYER_EXTEND_OFFSET : 0}

--- a/src/lib/shape.types.ts
+++ b/src/lib/shape.types.ts
@@ -3,10 +3,6 @@ import { z } from 'zod';
 
 export const SHAPE: ShapeIdentifier = 'CwRwCwCw:P-P-P-P-:P-P-P-P-:CcCcCcCc';
 
-export const SHAPE_MAX_LAYERS = 4;
-export const SHAPE_MAX_DEFAULT_PARTS = 4;
-export const SHAPE_MAX_HEX_PARTS = 6;
-
 export const SHAPE_COLOR_BASE = 0x333333;
 export const SHAPE_COLOR_NONE = 0x777777;
 export const SHAPE_COLOR_PIN = 0x444450;
@@ -85,7 +81,7 @@ export const SHAPE_COLOR_MATERIALS: Record<ShapeColorIdentifier, Material> = {
 	g: SHAPE_COLOR_GREEN_MATERIAL,
 	b: SHAPE_COLOR_BLUE_MATERIAL,
 	c: SHAPE_COLOR_CYAN_MATERIAL,
-	p: SHAPE_COLOR_PURPLE_MATERIAL,
+	m: SHAPE_COLOR_PURPLE_MATERIAL,
 	y: SHAPE_COLOR_YELLOW_MATERIAL,
 	k: SHAPE_COLOR_BLACK_MATERIAL,
 	w: SHAPE_COLOR_WHITE_MATERIAL,
@@ -147,7 +143,7 @@ export const SHAPE_CRYSTAL_MATERIALS: Record<ShapeColorIdentifier, Material> = {
 	g: SHAPE_CRYSTAL_GREEN_MATERIAL,
 	b: SHAPE_CRYSTAL_BLUE_MATERIAL,
 	c: SHAPE_CRYSTAL_CYAN_MATERIAL,
-	p: SHAPE_CRYSTAL_PURPLE_MATERIAL,
+	m: SHAPE_CRYSTAL_PURPLE_MATERIAL,
 	y: SHAPE_CRYSTAL_YELLOW_MATERIAL,
 	k: SHAPE_CRYSTAL_BLACK_MATERIAL,
 	w: SHAPE_CRYSTAL_WHITE_MATERIAL,
@@ -186,7 +182,7 @@ export const SHAPE_TYPE_IDENTIFIER = [
 	'-'
 ] as const;
 export type ShapeTypeIdentifier = (typeof SHAPE_TYPE_IDENTIFIER)[number];
-export const SHAPE_COLORS = ['r', 'g', 'b', 'c', 'p', 'y', 'k', 'w'] as const;
+export const SHAPE_COLORS = ['r', 'g', 'b', 'c', 'm', 'y', 'k', 'w'] as const;
 export type ShapeColor = (typeof SHAPE_COLORS)[number];
 export const SHAPE_COLOR_IDENTIFIERS = [...SHAPE_COLORS, 'u', '-'] as const;
 export type ShapeColorIdentifier = (typeof SHAPE_COLOR_IDENTIFIERS)[number];
@@ -200,10 +196,20 @@ export const SHAPE_LAYER_IDENTIFIER_SEPERATOR = ':';
 export const SHAPE_PART_REGEX = /(..?)/g;
 export const SHAPE_PART_PARAMETERS_REGEX = /(.?)/g;
 
-const SHAPE_DEFAULT_IDENTIFIER_REGEX =
-	/^([CRSWPc-][rgbcpykwu-]){1,4}(:([CRSWPc-][rgbcpykwu-]){1,4}){0,3}$/;
-const SHAPE_HEX_IDENTIFIER_REGEX =
-	/^([FGHPc-][rgbcpykwu-]){1,6}(:([FGHPc-][rgbcpykwu-]){1,6}){0,3}$/;
+export const SHAPE_MAX_LAYERS = 6;
+export const SHAPE_MAX_DEFAULT_PARTS = 4;
+export const SHAPE_MAX_HEX_PARTS = 6;
+const SHAPE_DEFAULT_PART_REGEX = `[CRSWPc-]`;
+const SHAPE_HEX_PART_REGEX = `[FGHPc-]`;
+const SHAPE_COLOR_REGEX = `[rgbcmykwu-]`;
+const SHAPE_DEFAULT_LAYER_REGEX = `${SHAPE_DEFAULT_PART_REGEX}${SHAPE_COLOR_REGEX}){1,${SHAPE_MAX_DEFAULT_PARTS}}`;
+const SHAPE_DEFAULT_IDENTIFIER_REGEX = new RegExp(
+	`^(${SHAPE_DEFAULT_LAYER_REGEX}(:(${SHAPE_DEFAULT_LAYER_REGEX})*$`
+);
+const SHAPE_HEX_LAYER_REGEX = `${SHAPE_HEX_PART_REGEX}${SHAPE_COLOR_REGEX}){1,${SHAPE_MAX_HEX_PARTS}}`;
+const SHAPE_HEX_IDENTIFIER_REGEX = new RegExp(
+	`^(${SHAPE_HEX_LAYER_REGEX}(:(${SHAPE_HEX_LAYER_REGEX})*$`
+);
 export const isDefaultShapeIdentifier = (identifier: ShapeIdentifier): boolean =>
 	z.string().regex(SHAPE_DEFAULT_IDENTIFIER_REGEX).safeParse(identifier).success;
 export const isHexShapeIdentifier = (identifier: ShapeIdentifier): boolean =>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -18,9 +18,8 @@ export const load = (async ({ locals, request, url }) => {
 	try {
 		const result = await get(locals.pb, { query: '', perPage: 100 });
 		searchBlueprints = result.items;
-	} catch (err) {
+	} catch {
 		searchBlueprints = [];
-		console.error(err);
 	}
 
 	// fetch the latest 100 users for client-side search
@@ -34,8 +33,8 @@ export const load = (async ({ locals, request, url }) => {
 		}
 		const result = (await response.json()) as ListResult<User>;
 		searchUsers = result.items;
-	} catch (err) {
-		console.error(err);
+	} catch {
+		searchUsers = [];
 	}	
 
 	return {


### PR DESCRIPTION
fix: use 'm' as shape color instead of 'p'
feat: add support for up to 6 shape layer
chore: remove console.error