### PR TITLE
fix(ci): use GitHub App token for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,17 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
@@ -128,8 +136,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Configure git
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'shapez-vortex-release[bot]'
+          git config user.email '${{ secrets.RELEASE_APP_ID }}+shapez-vortex-release[bot]@users.noreply.github.com'
       - name: Run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace github-actions[bot] identity with a dedicated shapez-vortex-release[bot] app so that release commits trigger downstream workflow runs (GitHub does not trigger workflows on commits made by github-actions[bot]).