### PR TITLE
fix(ci): make release job manual-only and revert v0.14.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -108,7 +109,7 @@ jobs:
   release:
     name: Release
     needs: [lint, check, format, build, test]
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     outputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 
-
-## v0.14.3
-
-[compare changes](https://github.com/DontMash/shapez-vortex/compare/v0.14.2...v0.14.3)
-
 ## v0.14.2
-
 
 ### 🚀 Enhancements
 
@@ -165,7 +159,7 @@
 - Update fullscreen assignment ([7eb48d9](https://github.com/DontMash/shapez-vortex/commit/7eb48d9))
 - Downgrade threejs dependency ([588d57a](https://github.com/DontMash/shapez-vortex/commit/588d57a))
 - Use 'm' as shape color instead of 'p' feat: add support for up to 6 shape layer chore: remove console.error ([4518c3e](https://github.com/DontMash/shapez-vortex/commit/4518c3e))
-- Use partial model for PipeGate  glas ([13f1bf1](https://github.com/DontMash/shapez-vortex/commit/13f1bf1))
+- Use partial model for PipeGate glas ([13f1bf1](https://github.com/DontMash/shapez-vortex/commit/13f1bf1))
 - Update lint/format command ([1d9f5e9](https://github.com/DontMash/shapez-vortex/commit/1d9f5e9))
 - Update wording on "more" blueprints ([15b89d7](https://github.com/DontMash/shapez-vortex/commit/15b89d7))
 - Add length condition to latest blueprint list ([9fb78ec](https://github.com/DontMash/shapez-vortex/commit/9fb78ec))
@@ -414,4 +408,3 @@
 
 - Sören Maschmann ([@DontMash](https://github.com/DontMash))
 - Sören Maschmann <smaschmann@slashwhy.de>
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shapez-visualizer",
-  "version": "0.14.3",
+  "version": "0.14.2",
   "type": "module",
   "private": true,
   "repository": {


### PR DESCRIPTION
The release job ran automatically on push to main, which caused unintended v0.14.2/v0.14.3 releases from the regenerated changelog. Gate the release job on workflow_dispatch so it only runs when manually triggered, and revert the v0.14.3 release entry along with the version bump.